### PR TITLE
✨ add support for Defillama API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # The database URL the application will use to connect to the database.
 DATABASE_URL='postgres://postgres:postgres@localhost:5432/postgres'
 
+# (Optional) Defillama API Key
+DEFILLAMA_API_KEY=
+
 # RPC URL
 RPC_URL=
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Make sure to first fill the envirronement file with your own config parameters:
 # The database URL the application will use to connect to the database.
 DATABASE_URL='postgres://postgres:postgres@localhost:5432/postgres'
 
+# (Optional) Defillama API Key
+DEFILLAMA_API_KEY=
+
 # RPC URL
 RPC_URL=
 

--- a/prometheus/alertmanager.yml
+++ b/prometheus/alertmanager.yml
@@ -58,4 +58,4 @@ receivers:
 
 # The directory from which notification templates are read.
 templates:
-  - '/etc/alertmanager/template/*.tmpl'
+  - "/etc/alertmanager/template/*.tmpl"

--- a/src/monitoring/price_deviation.rs
+++ b/src/monitoring/price_deviation.rs
@@ -38,11 +38,22 @@ pub async fn price_deviation<T: Entry>(
     let pair_id = query.pair_id().to_string();
     let coingecko_id = *ids.get(&pair_id).expect("Failed to get coingecko id");
 
-    let request_url = format!(
-        "https://coins.llama.fi/prices/historical/{timestamp}/coingecko:{id}",
-        timestamp = query.timestamp().timestamp(),
-        id = coingecko_id,
-    );
+    let api_key = std::env::var("DEFILLAMA_API_KEY");
+
+    let request_url = if let Ok(api_key) = api_key {
+        format!(
+            "https://coins.llama.fi/prices/historical/{timestamp}/coingecko:{id}?apikey={apikey}",
+            timestamp = query.timestamp().timestamp(),
+            id = coingecko_id,
+            apikey = api_key
+        )
+    } else {
+        format!(
+            "https://coins.llama.fi/prices/historical/{timestamp}/coingecko:{id}",
+            timestamp = query.timestamp().timestamp(),
+            id = coingecko_id,
+        )
+    };
 
     let response = reqwest::get(&request_url)
         .await


### PR DESCRIPTION
If provided in `.env`, defillama api key will be used. This is necessary to avoid rate-limiting.