### PR TITLE
✨ API Monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,9 +2310,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "starknet"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb139c5e6f6c6da627080e33cc00b3fc1c9733403034ca1ee9c42a95c337c7f"
+checksum = "36f8002bf3d750dd2c0434aca8b5e88e2438cd6c452f4c18f34d0a8a9f42cb1a"
 dependencies = [
  "starknet-accounts",
  "starknet-contract",
@@ -2326,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3743932c80ad2a5868c2dd4ef729de4e12060c88e73e4bb678a5f8e51b105e53"
+checksum = "e8e39a5807a735343493781dd5e640c4af838de470b0a73f420bed642fdc2ff1"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2340,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e55aac528c5376e1626d5a8d4daaf280bfd08f909dadc729e5b009203d6ec21"
+checksum = "b4996991356cd0e9499c663680eba7e77de4109e4995f652c1608899a65c09ee"
 dependencies = [
  "serde",
  "serde_json",
@@ -2355,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff50e281d4fdb97988a3d5c7b7cae22b9d67bb2ef9be2cfafc17a1e35542cb53"
+checksum = "5b15034c07557615f6bea248cb2ac91a103f56792c515319025a5edc4de2a60e"
 dependencies = [
  "base64 0.21.5",
  "flate2",
@@ -2428,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840be1a7eb5735863eee47d3a3f26df45b9be2c519e8da294e74b4d0524d77d1"
+checksum = "7c5d2964612f0ccd0a700279e33cfc98d6db04f64645ff834f3b7ec422142d7a"
 dependencies = [
  "starknet-core",
  "syn 2.0.41",
@@ -2438,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b08084f36ff7f11743ec71f33f0b11d439cbe0524058def299eb47de1ef1c28"
+checksum = "6a4bd1c262936543d6d14d299f476585e8c9625a4e284d9255b54f1c2e68e64a"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91919d8f318f0b5bcc4ff5849fbd3fb46adaaa72e0bf204742bab7c822425ff4"
+checksum = "8c5eb659e66b56ceafb9025cd601226d8f34d273f1b826cd4053ab6333ff0898"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ phf = { version = "0.11", features = ["macros"] }
 prometheus = "0.13.3"
 reqwest = { version = "0.11.22", features = ["json"] }
 serde = { version = "1.0.130", features = ["derive"] }
-starknet = "0.8.0"
+starknet = "0.9.0"
 strum = { version = "0.25.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 url = "2.5.0"

--- a/prometheus/alerts.rules.yml
+++ b/prometheus/alerts.rules.yml
@@ -42,7 +42,7 @@ groups:
           summary: "Indexer is down"
           description: "The {{ $labels.network }} indexer for {{ $labels.type }} is lagging behind 10 blocks."
   - name: API
-    rules: 
+    rules:
       - alert: TimeSinceLastUpdateTooHigh
         expr: api_time_since_last_update > 1800
         for: 5m

--- a/prometheus/alerts.rules.yml
+++ b/prometheus/alerts.rules.yml
@@ -41,3 +41,37 @@ groups:
         annotations:
           summary: "Indexer is down"
           description: "The {{ $labels.network }} indexer for {{ $labels.type }} is lagging behind 10 blocks."
+  - name: API
+    rules: 
+      - alert: TimeSinceLastUpdateTooHigh
+        expr: api_time_since_last_update > 1800
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Time since the last update is too high"
+          description: "The time since the last update for {{ $labels.pair }} has exceeded 1800 seconds."
+      - alert: WrongPrice
+        expr: api_price_deviation > 0.025
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Price deviation is too high"
+          description: "The price deviation of {{ $labels.pair }} from DefiLlama has exceeded 2.5%."
+      - alert: TooFewSources
+        expr: api_num_sources < 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Too few sources"
+          description: "The number of sources for {{ $labels.pair }} has fallen below 1."
+      - alert: SequencerDeviation
+        expr: api_sequencer_deviation > 0.02
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Sequencer deviation is too high"
+          description: "The ETH/STRK price has deviated from the sequencer price by more than 2%."

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -63,7 +63,7 @@ lazy_static! {
     pub static ref INDEXER_BLOCKS_LEFT: IntGaugeVec = register_int_gauge_vec!(
         opts!(
             "indexer_blocks_left",
-            "Number of blocks left to index for a give indexer."
+            "Number of blocks left to index for a given indexer."
         ),
         &["network", "type"]
     )
@@ -80,6 +80,14 @@ lazy_static! {
         opts!(
             "api_time_since_last_update",
             "Time since the last update in seconds."
+        ),
+        &["network", "pair"]
+    )
+    .unwrap();
+    pub static ref API_NUM_SOURCES: IntGaugeVec = register_int_gauge_vec!(
+        opts!(
+            "api_num_sources",
+            "Number of sources aggregated for a pair."
         ),
         &["network", "pair"]
     )

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -68,4 +68,12 @@ lazy_static! {
         &["network", "type"]
     )
     .unwrap();
+    pub static ref API_PRICE_DEVIATION: GaugeVec = register_gauge_vec!(
+        opts!(
+            "api_price_deviation",
+            "Price deviation from the reference price."
+        ),
+        &["pair"]
+    )
+    .unwrap();
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -73,7 +73,15 @@ lazy_static! {
             "api_price_deviation",
             "Price deviation from the reference price."
         ),
-        &["pair"]
+        &["network", "pair"]
+    )
+    .unwrap();
+    pub static ref API_TIME_SINCE_LAST_UPDATE: GaugeVec = register_gauge_vec!(
+        opts!(
+            "api_time_since_last_update",
+            "Time since the last update in seconds."
+        ),
+        &["network", "pair"]
     )
     .unwrap();
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -92,4 +92,12 @@ lazy_static! {
         &["network", "pair"]
     )
     .unwrap();
+    pub static ref API_SEQUENCER_DEVIATION: GaugeVec = register_gauge_vec!(
+        opts!(
+            "api_sequencer_deviation",
+            "Price deviation from starknet gateway price."
+        ),
+        &["network"]
+    )
+    .unwrap();
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ pub enum MonitoringError {
     Conversion(String),
     OnChain(String),
     Provider(ProviderError),
+    InvalidTimestamp(u64),
 }
 
 impl StdError for MonitoringError {}
@@ -25,6 +26,7 @@ impl fmt::Display for MonitoringError {
             MonitoringError::Conversion(e) => write!(f, "Conversion Error: {}", e),
             MonitoringError::OnChain(e) => write!(f, "OnChain Error: {}", e),
             MonitoringError::Provider(e) => write!(f, "Provider Error: {}", e),
+            MonitoringError::InvalidTimestamp(e) => write!(f, "Invalid Timestamp: {}", e),
         }
     }
 }

--- a/src/monitoring/price_deviation.rs
+++ b/src/monitoring/price_deviation.rs
@@ -28,7 +28,7 @@ struct CoinPriceDTO {
     confidence: f64,
 }
 
-/// Calculates the deviation of the price from a trusted API (Coingecko)
+/// Calculates the deviation of the price from a trusted API (DefiLLama)
 pub async fn price_deviation<T: Entry>(
     query: &T,
     normalized_price: f64,
@@ -78,4 +78,52 @@ pub async fn price_deviation<T: Entry>(
         .price;
 
     Ok((normalized_price - reference_price) / reference_price)
+}
+
+/// Calculates the raw deviation of the price from a trusted API (DefiLLama)
+pub async fn raw_price_deviation(pair_id: &String, price: f64) -> Result<f64, MonitoringError> {
+    let ids = &COINGECKO_IDS;
+
+    let coingecko_id = *ids.get(pair_id).expect("Failed to get coingecko id");
+
+    let api_key = std::env::var("DEFILLAMA_API_KEY");
+
+    let request_url = if let Ok(api_key) = api_key {
+        format!(
+            "https://coins.llama.fi/prices/historical/{timestamp}/coingecko:{id}?apikey={apikey}",
+            timestamp = chrono::Utc::now().timestamp(),
+            id = coingecko_id,
+            apikey = api_key
+        )
+    } else {
+        format!(
+            "https://coins.llama.fi/prices/historical/{timestamp}/coingecko:{id}",
+            timestamp = chrono::Utc::now().timestamp(),
+            id = coingecko_id,
+        )
+    };
+
+    let response = reqwest::get(&request_url)
+        .await
+        .map_err(|e| MonitoringError::Api(e.to_string()))?;
+
+    let coins_prices: CoinPricesDTO = response.json().await.map_err(|e| {
+        MonitoringError::Api(format!(
+            "Failed to convert to DTO object, got error {:?}",
+            e.to_string()
+        ))
+    })?;
+
+    let api_id = format!("coingecko:{}", coingecko_id);
+
+    let reference_price = coins_prices
+        .coins
+        .get(&api_id)
+        .ok_or(MonitoringError::Api(format!(
+            "Failed to get coingecko price for id {:?}",
+            coingecko_id
+        )))?
+        .price;
+
+    Ok((price - reference_price) / reference_price)
 }

--- a/src/monitoring/time_since_last_update.rs
+++ b/src/monitoring/time_since_last_update.rs
@@ -1,5 +1,5 @@
-use crate::types::Entry;
-use chrono::{DateTime, TimeZone, Utc};
+use crate::{error::MonitoringError, types::Entry};
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
 use std::time::SystemTime;
 
 /// Calculate the time since the last update in seconds.
@@ -9,4 +9,18 @@ pub fn time_since_last_update<T: Entry>(query: &T) -> u64 {
     let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH);
 
     now.unwrap().as_secs() - timestamp as u64
+}
+
+/// Calculate the raw time since the last update in seconds.
+pub fn raw_time_since_last_update(timestamp: u64) -> Result<u64, MonitoringError> {
+    let datetime = match Utc.timestamp_millis_opt(timestamp as i64) {
+        LocalResult::Single(datetime) => datetime,
+        _ => {
+            return Err(MonitoringError::InvalidTimestamp(timestamp));
+        }
+    };
+    let timestamp = datetime.timestamp();
+    let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH);
+
+    Ok(now.unwrap().as_secs() - timestamp as u64)
 }

--- a/src/processing/api.rs
+++ b/src/processing/api.rs
@@ -1,0 +1,21 @@
+use crate::{
+    constants::API_PRICE_DEVIATION, error::MonitoringError,
+    monitoring::price_deviation::raw_price_deviation, processing::common::query_pragma_api,
+};
+
+pub async fn process_data_by_pair(pair: String) -> Result<f64, MonitoringError> {
+    // Query the Pragma API
+    let result = query_pragma_api(&pair).await?;
+
+    log::info!("Processing data for pair: {}", pair);
+
+    let normalized_price =
+        result.price.parse::<f64>().unwrap() / 10_f64.powi(result.decimals as i32);
+
+    let price_deviation = raw_price_deviation(&pair, normalized_price).await?;
+    API_PRICE_DEVIATION
+        .with_label_values(&[&pair])
+        .set(price_deviation);
+
+    Ok(price_deviation)
+}

--- a/src/processing/api.rs
+++ b/src/processing/api.rs
@@ -1,11 +1,19 @@
 use crate::{
-    constants::API_PRICE_DEVIATION, error::MonitoringError,
-    monitoring::price_deviation::raw_price_deviation, processing::common::query_pragma_api,
+    config::get_config,
+    constants::{API_PRICE_DEVIATION, API_TIME_SINCE_LAST_UPDATE},
+    error::MonitoringError,
+    monitoring::{
+        price_deviation::raw_price_deviation, time_since_last_update::raw_time_since_last_update,
+    },
+    processing::common::query_pragma_api,
 };
 
 pub async fn process_data_by_pair(pair: String) -> Result<f64, MonitoringError> {
     // Query the Pragma API
-    let result = query_pragma_api(&pair).await?;
+    let config = get_config(None).await;
+    let network_env = &config.network_str();
+
+    let result = query_pragma_api(&pair, network_env).await?;
 
     log::info!("Processing data for pair: {}", pair);
 
@@ -13,9 +21,14 @@ pub async fn process_data_by_pair(pair: String) -> Result<f64, MonitoringError> 
         result.price.parse::<f64>().unwrap() / 10_f64.powi(result.decimals as i32);
 
     let price_deviation = raw_price_deviation(&pair, normalized_price).await?;
+    let time_since_last_update = raw_time_since_last_update(result.timestamp)?;
+
     API_PRICE_DEVIATION
-        .with_label_values(&[&pair])
+        .with_label_values(&[network_env, &pair])
         .set(price_deviation);
+    API_TIME_SINCE_LAST_UPDATE
+        .with_label_values(&[network_env, &pair])
+        .set(time_since_last_update as f64);
 
     Ok(price_deviation)
 }

--- a/src/processing/api.rs
+++ b/src/processing/api.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::get_config,
-    constants::{API_PRICE_DEVIATION, API_TIME_SINCE_LAST_UPDATE},
+    constants::{API_NUM_SOURCES, API_PRICE_DEVIATION, API_TIME_SINCE_LAST_UPDATE},
     error::MonitoringError,
     monitoring::{
         price_deviation::raw_price_deviation, time_since_last_update::raw_time_since_last_update,
@@ -29,6 +29,9 @@ pub async fn process_data_by_pair(pair: String) -> Result<f64, MonitoringError> 
     API_TIME_SINCE_LAST_UPDATE
         .with_label_values(&[network_env, &pair])
         .set(time_since_last_update as f64);
+    API_NUM_SOURCES
+        .with_label_values(&[network_env, &pair])
+        .set(result.num_sources_aggregated as i64);
 
     Ok(price_deviation)
 }

--- a/src/processing/common.rs
+++ b/src/processing/common.rs
@@ -114,11 +114,10 @@ pub struct PragmaDataDTO {
 }
 
 /// Queries Pragma API
-pub async fn query_pragma_api(pair: &str) -> Result<PragmaDataDTO, MonitoringError> {
-    let config = get_config(None).await;
-
-    let network_env = config.network_str();
-
+pub async fn query_pragma_api(
+    pair: &str,
+    network_env: &str,
+) -> Result<PragmaDataDTO, MonitoringError> {
     let request_url = match network_env {
         "testnet" => format!(
             "https://api.dev.pragma.build/node/v1/data/{pair}?routing=true",

--- a/src/processing/common.rs
+++ b/src/processing/common.rs
@@ -94,3 +94,51 @@ async fn blocks_left(
         Ok(None)
     }
 }
+
+/// Data Transfer Object for Pragma API
+/// e.g
+/// {
+//     "num_sources_aggregated": 2,
+//     "pair_id": "ETH/STRK",
+//     "price": "0xd136e79f57d9198",
+//     "timestamp": 1705669200000,
+//     "decimals": 18
+// }
+#[derive(serde::Deserialize, Debug)]
+pub struct PragmaDataDTO {
+    pub num_sources_aggregated: u32,
+    pub pair_id: String,
+    pub price: String,
+    pub timestamp: u64,
+    pub decimals: u32,
+}
+
+/// Queries Pragma API
+pub async fn query_pragma_api(pair: &str) -> Result<PragmaDataDTO, MonitoringError> {
+    let config = get_config(None).await;
+
+    let network_env = config.network_str();
+
+    let request_url = match network_env {
+        "testnet" => format!(
+            "https://api.dev.pragma.build/node/v1/data/{pair}?routing=true",
+            pair = pair,
+        ),
+        "mainnet" => format!(
+            "https://api.prod.pragma.build/node/v1/data/{pair}?routing=true",
+            pair = pair,
+        ),
+        _ => panic!("Invalid network env"),
+    };
+
+    let response = reqwest::get(&request_url)
+        .await
+        .map_err(|e| MonitoringError::Api(e.to_string()))?;
+
+    let data = response
+        .json::<PragmaDataDTO>()
+        .await
+        .map_err(|e| MonitoringError::Api(e.to_string()))?;
+
+    Ok(data)
+}

--- a/src/processing/future.rs
+++ b/src/processing/future.rs
@@ -54,8 +54,6 @@ pub async fn process_data_by_pair(
 
     log::info!("Processing data for pair: {}", pair);
 
-    let config = get_config(None).await;
-
     match result {
         Ok(data) => {
             let network_env = &config.network_str();

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod common;
 pub mod future;
 pub mod spot;

--- a/src/processing/spot.rs
+++ b/src/processing/spot.rs
@@ -54,8 +54,6 @@ pub async fn process_data_by_pair(
 
     log::info!("Processing data for pair: {}", pair);
 
-    let config = get_config(None).await;
-
     match result {
         Ok(data) => {
             let network_env = &config.network_str();


### PR DESCRIPTION
- Adds monitoring for the [Pragma API](https://docs.pragma.build/Resources/PragmApi/get-started) in a new thread
- Calls the `dev` or `prod` endpoint based on the chosen network (testnet/mainnet)

Adds the following metrics:
- [x] `api_price_deviation{network, pair_id}`: deviation of the API price from a "trusted" source
- [x] `api_time_since_last_update{network, pair_id}`: time since last update for a given pair
- [x] `api_number_of_sources{network, pair_id}`: number of sources aggregated for a given pair
- [x] `api_sequencer_deviation`: deviation of the sequencer strk gas price from the expected one (cc https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=pending)