### PR TITLE
Revert changes UTC

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -66,7 +66,6 @@ pub struct Config {
 /// inspired from here - https://github.com/matklad/once_cell/issues/127
 pub static CONFIG: OnceCell<ArcSwap<Config>> = OnceCell::const_new();
 
-#[allow(dead_code)]
 impl Config {
     pub async fn new(config_input: ConfigInput) -> Self {
         let indexer_url =
@@ -167,7 +166,6 @@ pub struct ConfigInput {
     pub future_pairs: Vec<String>,
 }
 
-#[allow(dead_code)]
 pub async fn get_config(config_input: Option<ConfigInput>) -> Guard<Arc<Config>> {
     let cfg = CONFIG
         .get_or_init(|| async {
@@ -183,7 +181,6 @@ pub async fn get_config(config_input: Option<ConfigInput>) -> Guard<Arc<Config>>
 /// This function is used to periodically update the configuration settings
 /// from the environment variables. This is useful when we want to update the
 /// configuration settings without restarting the service.
-#[allow(dead_code)]
 pub async fn periodic_config_update() {
     let interval = Duration::from_secs(CONFIG_UPDATE_INTERVAL); // Set the update interval as needed (3 hours in this example)
 
@@ -209,7 +206,6 @@ pub async fn periodic_config_update() {
 /// set it up again for reuse in new tests. By calling `config_force_init` we replace the already
 /// stored config inside `ArcSwap` with the new configuration and pool settings.
 #[cfg(test)]
-#[allow(dead_code)]
 pub async fn config_force_init(config_input: ConfigInput) {
     match CONFIG.get() {
         Some(arc) => arc.store(Arc::new(Config::new(config_input).await)),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,7 +2,6 @@ use lazy_static::lazy_static;
 use phf::phf_map;
 use prometheus::{opts, register_gauge_vec, register_int_gauge_vec, GaugeVec, IntGaugeVec};
 
-#[allow(dead_code)]
 pub(crate) static COINGECKO_IDS: phf::Map<&'static str, &'static str> = phf_map! {
     "BTC/USD" => "bitcoin",
     "ETH/USD" => "ethereum",
@@ -118,9 +117,7 @@ lazy_static! {
     .unwrap();
 }
 
-#[allow(dead_code)]
 pub const FEE_TOKEN_DECIMALS: i32 = 18;
-#[allow(dead_code)]
 pub const FEE_TOKEN_ADDRESS: &str =
     "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7";
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::all)]
 
 use bigdecimal::BigDecimal;
-use chrono::{DateTime, Utc};
+use chrono::NaiveDateTime;
 use diesel::{Queryable, QueryableByName, Selectable};
 use num_bigint::BigInt;
 use std::ops::Bound;
@@ -18,10 +18,10 @@ pub struct SpotEntry {
     pub data_id: String,
     pub block_hash: String,
     pub block_number: i64,
-    pub block_timestamp: DateTime<Utc>,
+    pub block_timestamp: NaiveDateTime,
     pub transaction_hash: String,
     pub price: BigDecimal,
-    pub timestamp: DateTime<Utc>,
+    pub timestamp: NaiveDateTime,
     pub publisher: String,
     pub source: String,
     pub volume: BigDecimal,
@@ -37,14 +37,14 @@ pub struct FutureEntry {
     pub data_id: String,
     pub block_hash: String,
     pub block_number: i64,
-    pub block_timestamp: DateTime<Utc>,
+    pub block_timestamp: NaiveDateTime,
     pub transaction_hash: String,
     pub price: BigDecimal,
-    pub timestamp: DateTime<Utc>,
+    pub timestamp: NaiveDateTime,
     pub publisher: String,
     pub source: String,
     pub volume: BigDecimal,
-    pub expiration_timestamp: Option<DateTime<Utc>>,
+    pub expiration_timestamp: Option<NaiveDateTime>,
     pub _cursor: i64,
 }
 
@@ -58,13 +58,13 @@ pub struct SpotCheckpoint {
     pub data_id: String,
     pub block_hash: String,
     pub block_number: i64,
-    pub block_timestamp: DateTime<Utc>,
+    pub block_timestamp: NaiveDateTime,
     pub transaction_hash: String,
     pub price: BigDecimal,
     pub sender_address: String,
     pub aggregation_mode: BigDecimal,
     pub _cursor: i64,
-    pub timestamp: DateTime<Utc>,
+    pub timestamp: NaiveDateTime,
     pub nb_sources_aggregated: BigDecimal,
 }
 
@@ -76,13 +76,13 @@ pub struct VrfRequest {
     pub network: String,
     pub request_id: BigDecimal,
     pub seed: BigDecimal,
-    pub created_at: DateTime<Utc>,
+    pub created_at: NaiveDateTime,
     pub created_at_tx: String,
     pub callback_address: String,
     pub callback_fee_limit: BigDecimal,
     pub num_words: BigDecimal,
     pub requestor_address: String,
-    pub updated_at: DateTime<Utc>,
+    pub updated_at: NaiveDateTime,
     pub updated_at_tx: String,
     pub status: BigDecimal,
     pub minimum_block_number: BigDecimal,

--- a/src/monitoring/time_since_last_update.rs
+++ b/src/monitoring/time_since_last_update.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 
 /// Calculate the time since the last update in seconds.
 pub fn time_since_last_update<T: Entry>(query: &T) -> u64 {
-    let datetime: DateTime<Utc> = query.timestamp();
+    let datetime: DateTime<Utc> = TimeZone::from_utc_datetime(&Utc, &query.timestamp());
     let timestamp = datetime.timestamp();
     let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH);
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -11,17 +11,17 @@ diesel::table! {
         #[max_length = 255]
         block_hash -> Varchar,
         block_number -> Int8,
-        block_timestamp -> Timestamptz,
+        block_timestamp -> Timestamp,
         #[max_length = 255]
         transaction_hash -> Varchar,
         price -> Numeric,
-        timestamp -> Timestamptz,
+        timestamp -> Timestamp,
         #[max_length = 255]
         publisher -> Varchar,
         #[max_length = 255]
         source -> Varchar,
         volume -> Numeric,
-        expiration_timestamp -> Nullable<Timestamptz>,
+        expiration_timestamp -> Nullable<Timestamp>,
         _cursor -> Int8,
     }
 }
@@ -37,17 +37,17 @@ diesel::table! {
         #[max_length = 255]
         block_hash -> Varchar,
         block_number -> Int8,
-        block_timestamp -> Timestamptz,
+        block_timestamp -> Timestamp,
         #[max_length = 255]
         transaction_hash -> Varchar,
         price -> Numeric,
-        timestamp -> Timestamptz,
+        timestamp -> Timestamp,
         #[max_length = 255]
         publisher -> Varchar,
         #[max_length = 255]
         source -> Varchar,
         volume -> Numeric,
-        expiration_timestamp -> Nullable<Timestamptz>,
+        expiration_timestamp -> Nullable<Timestamp>,
         _cursor -> Int8,
     }
 }
@@ -63,11 +63,11 @@ diesel::table! {
         #[max_length = 255]
         block_hash -> Varchar,
         block_number -> Int8,
-        block_timestamp -> Timestamptz,
+        block_timestamp -> Timestamp,
         #[max_length = 255]
         transaction_hash -> Varchar,
         price -> Numeric,
-        timestamp -> Timestamptz,
+        timestamp -> Timestamp,
         #[max_length = 255]
         publisher -> Varchar,
         #[max_length = 255]
@@ -88,11 +88,11 @@ diesel::table! {
         #[max_length = 255]
         block_hash -> Varchar,
         block_number -> Int8,
-        block_timestamp -> Timestamptz,
+        block_timestamp -> Timestamp,
         #[max_length = 255]
         transaction_hash -> Varchar,
         price -> Numeric,
-        timestamp -> Timestamptz,
+        timestamp -> Timestamp,
         #[max_length = 255]
         publisher -> Varchar,
         #[max_length = 255]
@@ -113,7 +113,7 @@ diesel::table! {
         #[max_length = 255]
         block_hash -> Varchar,
         block_number -> Int8,
-        block_timestamp -> Timestamptz,
+        block_timestamp -> Timestamp,
         #[max_length = 255]
         transaction_hash -> Varchar,
         price -> Numeric,
@@ -121,7 +121,7 @@ diesel::table! {
         sender_address -> Varchar,
         aggregation_mode -> Numeric,
         _cursor -> Int8,
-        timestamp -> Timestamptz,
+        timestamp -> Timestamp,
         nb_sources_aggregated -> Numeric,
     }
 }
@@ -137,7 +137,7 @@ diesel::table! {
         #[max_length = 255]
         block_hash -> Varchar,
         block_number -> Int8,
-        block_timestamp -> Timestamptz,
+        block_timestamp -> Timestamp,
         #[max_length = 255]
         transaction_hash -> Varchar,
         price -> Numeric,
@@ -145,7 +145,7 @@ diesel::table! {
         sender_address -> Varchar,
         aggregation_mode -> Numeric,
         _cursor -> Int8,
-        timestamp -> Timestamptz,
+        timestamp -> Timestamp,
         nb_sources_aggregated -> Numeric,
     }
 }
@@ -156,14 +156,14 @@ diesel::table! {
         network -> Varchar,
         request_id -> Numeric,
         seed -> Numeric,
-        created_at -> Timestamptz,
+        created_at -> Timestamp,
         created_at_tx -> Varchar,
         #[max_length = 255]
         callback_address -> Varchar,
         callback_fee_limit -> Numeric,
         num_words -> Numeric,
         requestor_address -> Varchar,
-        updated_at -> Timestamptz,
+        updated_at -> Timestamp,
         updated_at_tx -> Varchar,
         status -> Numeric,
         minimum_block_number -> Numeric,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use bigdecimal::BigDecimal;
-use chrono::{DateTime, Utc};
+use chrono::NaiveDateTime;
 
 use crate::{
     config::DataType,
@@ -10,10 +10,10 @@ use crate::{
 pub trait Entry {
     fn pair_id(&self) -> &str;
     fn source(&self) -> &str;
-    fn timestamp(&self) -> DateTime<Utc>;
+    fn timestamp(&self) -> NaiveDateTime;
     fn block_number(&self) -> i64;
     fn price(&self) -> BigDecimal;
-    fn expiration_timestamp(&self) -> Option<DateTime<Utc>>;
+    fn expiration_timestamp(&self) -> Option<NaiveDateTime>;
     fn data_type(&self) -> DataType;
 }
 
@@ -26,7 +26,7 @@ impl Entry for SpotEntry {
         &self.source
     }
 
-    fn timestamp(&self) -> DateTime<Utc> {
+    fn timestamp(&self) -> NaiveDateTime {
         self.timestamp
     }
 
@@ -38,7 +38,7 @@ impl Entry for SpotEntry {
         self.price.clone()
     }
 
-    fn expiration_timestamp(&self) -> Option<DateTime<Utc>> {
+    fn expiration_timestamp(&self) -> Option<NaiveDateTime> {
         None
     }
 
@@ -56,7 +56,7 @@ impl Entry for FutureEntry {
         &self.source
     }
 
-    fn timestamp(&self) -> DateTime<Utc> {
+    fn timestamp(&self) -> NaiveDateTime {
         self.timestamp
     }
 
@@ -68,7 +68,7 @@ impl Entry for FutureEntry {
         self.price.clone()
     }
 
-    fn expiration_timestamp(&self) -> Option<DateTime<Utc>> {
+    fn expiration_timestamp(&self) -> Option<NaiveDateTime> {
         self.expiration_timestamp
     }
 


### PR DESCRIPTION
We have alerts in our testnet about entries not being published for a long time even though they are.

Probably related to this timezone change.

We decided to revert it.