### PR TITLE
fix: dockerfile typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
- # syntax=docker/dockerfile-upstream:master
+# syntax=docker/dockerfile-upstream:master
 
 ARG RUST_VERSION=1.72.0
 FROM lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION}-slim-bullseye AS cargo-chef
@@ -22,18 +22,17 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 RUN cargo chef cook --profile release --recipe-path recipe.json 
 COPY . .
 RUN cargo build --locked --release
-ARG APP_NAME=pragma-monitoring
-ENV APP_NAME $APP_NAME
-RUN cp /app/target/release/$APP_NAME /bin/server
 
 FROM debian:bullseye-slim AS final
-RUN apt-get update && DEBIEN_FRONTEND=noninteractive apt-get install -y \ 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \ 
     libpq-dev \
     libssl1.1 \
     procps \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /bin/server /bin/
+ARG APP_NAME=pragma-monitoring
+ENV APP_NAME $APP_NAME
+COPY --from=builder /app/target/release/${APP_NAME} /bin/server
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 RUN adduser \
@@ -50,4 +49,4 @@ EXPOSE 8080
 
 ENV RUST_LOG=info
 
-CMD ["/bin/server"]￼
+CMD ["/bin/server"]


### PR DESCRIPTION
## Changes
- Removed the RUN cp /app/target/release/$APP_NAME /bin/server line from the builder stage. This was unnecessary and potentially problematic if the $APP_NAME variable wasn't set correctly.
- Moved the ARG APP_NAME=pragma-monitoring and ENV APP_NAME $APP_NAME lines to the final stage, where they're actually used.
- Changed the COPY command in the final stage to:
dockerfileCopyCOPY --from=builder /app/target/release/${APP_NAME} /bin/server
This directly copies the built binary from the builder stage to the /bin/server location in the final stage, using the APP_NAME variable.
- Fixed a typo in the final stage: Changed DEBIEN_FRONTEND to DEBIAN_FRONTEND.